### PR TITLE
refactor enhance class context and support disable any plugin

### DIFF
--- a/agent-core/src/main/java/cloud/erda/agent/core/config/AgentConfig.java
+++ b/agent-core/src/main/java/cloud/erda/agent/core/config/AgentConfig.java
@@ -18,8 +18,11 @@ package cloud.erda.agent.core.config;
 
 import cloud.erda.agent.core.config.loader.Config;
 import cloud.erda.agent.core.config.loader.Configuration;
+import cloud.erda.agent.core.config.loader.MapConfiguration;
 import org.apache.skywalking.apm.agent.core.logging.core.LogLevel;
 import org.apache.skywalking.apm.agent.core.util.Strings;
+
+import java.util.Map;
 
 public class AgentConfig implements Config {
     @Configuration(name = "TERMINUS_KEY", defaultValue = "")
@@ -52,8 +55,12 @@ public class AgentConfig implements Config {
     @Configuration(name = "MSP_ENV_ID", defaultValue = "")
     private String _mspEnvId;
 
+
     @Configuration(name = "MSP_ENV_TOKEN", defaultValue = "")
     private String _mspEnvToken;
+
+    @MapConfiguration(pattern = "MSP_PLUGIN_.*._ENABLED", valueType = Boolean.class)
+    private Map<String, Boolean> _pluginEnabled;
 
     public String terminusKey() {
         if (!Strings.isEmpty(_terminusKey)) {
@@ -96,5 +103,9 @@ public class AgentConfig implements Config {
 
     public String agentOsInfo() {
         return this._agentOsInfo;
+    }
+
+    public Map<String, Boolean> pluginEnabled() {
+        return _pluginEnabled;
     }
 }

--- a/agent-core/src/main/java/cloud/erda/agent/core/config/loader/ConfigLoader.java
+++ b/agent-core/src/main/java/cloud/erda/agent/core/config/loader/ConfigLoader.java
@@ -57,7 +57,6 @@ public abstract class ConfigLoader {
                     if (!validateValue(item.getKey(), item.getValue(), field)) {
                         continue;
                     }
-//                    log.debug("Try matches {} map config {} item {}={} from {}", instance.getClass().getSimpleName(), mapConfiguration.pattern(), item.getKey(), item.getValue(), getClass().getSimpleName());
                     if (item.getKey().matches(mapConfiguration.pattern())) {
                         Object value = ReflectionUtils.castValue(item.getValue(), mapConfiguration.valueType());
                         map.put(item.getKey(), value);
@@ -94,17 +93,4 @@ public abstract class ConfigLoader {
             log.info("!Error. Load {} config {} from {}", instance.getClass().getSimpleName(), name, getClass().getSimpleName());
         }
     }
-
-//    private void loadValue(String name, String value, Object instance, Field field) {
-//        if (validateValue(name, value, instance, field)) {
-//            try {
-//                field.setAccessible(true);
-//                Object fieldValue = ReflectionUtils.castValue(value, field.getType());
-//                field.set(instance, fieldValue);
-//                log.info("Load {} config {}={} from {}", instance.getClass().getSimpleName(), name, fieldValue, getClass().getSimpleName());
-//            } catch (IllegalAccessException e) {
-//                log.info("!Error. Load {} config {}={} from {}", instance.getClass().getSimpleName(), name, value, getClass().getSimpleName());
-//            }
-//        }
-//    }
 }

--- a/agent-core/src/main/java/cloud/erda/agent/core/config/loader/DefaultValueConfigLoader.java
+++ b/agent-core/src/main/java/cloud/erda/agent/core/config/loader/DefaultValueConfigLoader.java
@@ -41,7 +41,7 @@ public class DefaultValueConfigLoader extends ConfigLoader {
     }
 
     @Override
-    protected boolean validateValue(String name, String value, Object instance, Field field) {
+    protected boolean validateValue(String name, String value,  Field field) {
         return true;
     }
 }

--- a/agent-core/src/main/java/cloud/erda/agent/core/config/loader/MapConfiguration.java
+++ b/agent-core/src/main/java/cloud/erda/agent/core/config/loader/MapConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Terminus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cloud.erda.agent.core.config.loader;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author liuhaoyang
+ * @date 2021/11/4 13:40
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MapConfiguration {
+
+    String pattern();
+
+    Class valueType();
+}

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/AbstractClassEnhancePluginDefine.java
@@ -53,7 +53,7 @@ public abstract class AbstractClassEnhancePluginDefine {
             return null;
         }
 
-        logger.debug("prepare to enhance class {} by {}.", transformClassName, interceptorDefineClassName);
+//        logger.debug("prepare to enhance class {} by {}.", transformClassName, interceptorDefineClassName);
 
         /**
          * find witness classes for enhance class
@@ -75,7 +75,7 @@ public abstract class AbstractClassEnhancePluginDefine {
         DynamicType.Builder<?> newClassBuilder = this.enhance(transformClassName, builder, classLoader, context);
 
         context.initializationStageCompleted();
-        logger.debug("enhance class {} by {} completely.", transformClassName, interceptorDefineClassName);
+        logger.debug("prepare to enhance class {} by {}.", transformClassName, interceptorDefineClassName);
 
         return newClassBuilder;
     }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/EnhanceContext.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/EnhanceContext.java
@@ -19,6 +19,7 @@
 
 package org.apache.skywalking.apm.agent.core.plugin;
 
+import net.bytebuddy.description.type.TypeDescription;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.ClassEnhancePluginDefine;
 
 /**
@@ -36,6 +37,16 @@ public class EnhanceContext {
      * e.g. added the new field, or implemented the new interface
      */
     private boolean objectExtended = false;
+
+    private TypeDescription typeDescription;
+
+    public TypeDescription getTypeDescription() {
+        return typeDescription;
+    }
+
+    public void setTypeDescription(TypeDescription typeDescription) {
+        this.typeDescription = typeDescription;
+    }
 
     public boolean isEnhanced() {
         return isEnhanced;

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginDefine.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginDefine.java
@@ -53,6 +53,10 @@ public class PluginDefine {
         return new PluginDefine(pluginName, defineClass);
     }
 
+    public String getName() {
+        return name;
+    }
+
     public String getDefineClass() {
         return defineClass;
     }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginGroup.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginGroup.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Terminus, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.skywalking.apm.agent.core.plugin;
+
+import org.apache.skywalking.apm.agent.core.util.Strings;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author liuhaoyang
+ * @date 2021/11/4 14:02
+ */
+public class PluginGroup {
+
+    private final String name;
+
+    private final List<AbstractClassEnhancePluginDefine> pluginDefines;
+
+    private PluginGroup(String name, List<AbstractClassEnhancePluginDefine> pluginDefines) {
+        this.name = name;
+        this.pluginDefines = pluginDefines;
+    }
+
+    private PluginGroup(String name) {
+        this(name, new ArrayList<>());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean empty() {
+        return Strings.isEmpty(name) || pluginDefines.size() == 0;
+    }
+
+    public List<AbstractClassEnhancePluginDefine> getPluginDefines() {
+        return pluginDefines;
+    }
+
+    public static PluginGroup group(String name) {
+        return new PluginGroup(name);
+    }
+}

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginLoader.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginLoader.java
@@ -18,7 +18,7 @@
 
 package org.apache.skywalking.apm.agent.core.plugin;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * @author liuhaoyang
@@ -26,5 +26,5 @@ import java.util.List;
  */
 public interface PluginLoader {
 
-    List<AbstractClassEnhancePluginDefine> load() throws Exception;
+    Collection<PluginGroup> load() throws Exception;
 }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginResourcesResolver.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/PluginResourcesResolver.java
@@ -47,7 +47,7 @@ public class PluginResourcesResolver {
             while (urls.hasMoreElements()) {
                 URL pluginUrl = urls.nextElement();
                 cfgUrlPaths.add(pluginUrl);
-                logger.info("find erda-agent plugin define in {}", pluginUrl);
+//                logger.info("find erda-agent plugin define in {}", pluginUrl);
             }
 
             return cfgUrlPaths;

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/context/IMethodInterceptContext.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/context/IMethodInterceptContext.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Method;
 
 public interface IMethodInterceptContext {
 
-    EnhancedInstance getInstance();
+    Object getInstance();
 
     Class<?> getOriginClass();
 

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/context/MethodInterceptContext.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/context/MethodInterceptContext.java
@@ -27,14 +27,14 @@ import java.util.Map;
 
 public class MethodInterceptContext implements IMethodInterceptContext {
     private Map<String, Object> attachments;
-    private EnhancedInstance instance;
+    private Object instance;
     private Class<?> originClass;
     private Method method;
     private Object[] arguments;
     private Class<?>[] argumentsTypes;
     private Throwable exception;
 
-    public MethodInterceptContext(EnhancedInstance objInst, Class<?> originClass, Method method, Object[] allArguments,
+    public MethodInterceptContext(Object objInst, Class<?> originClass, Method method, Object[] allArguments,
                                   Class<?>[] argumentsTypes) {
         this.instance = objInst;
         this.originClass = originClass;
@@ -44,7 +44,7 @@ public class MethodInterceptContext implements IMethodInterceptContext {
     }
 
     @Override
-    public EnhancedInstance getInstance() {
+    public Object getInstance() {
         return instance;
     }
 

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassEnhancePluginDefine.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassEnhancePluginDefine.java
@@ -116,8 +116,8 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
          *
          */
         if (!context.isObjectExtended()) {
-            newClassBuilder = newClassBuilder.implement(EnhancedInstance.class);
-            if (implementDynamicField()) {
+//            newClassBuilder = newClassBuilder.implement(EnhancedInstance.class);
+            if (implementDynamicField() && !context.getTypeDescription().isAssignableTo(DynamicFieldEnhancedInstance.class)) {
                 newClassBuilder = newClassBuilder.defineField(CONTEXT_ATTR_NAME, Object.class, ACC_PRIVATE)
                         .implement(DynamicFieldEnhancedInstance.class)
                         .intercept(FieldAccessor.ofField(CONTEXT_ATTR_NAME));
@@ -186,7 +186,9 @@ public abstract class ClassEnhancePluginDefine extends AbstractClassEnhancePlugi
      */
     protected abstract InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints();
 
-    protected abstract boolean implementDynamicField();
+    protected boolean implementDynamicField() {
+        return false;
+    }
 
     /**
      * Enhance a class to intercept class static methods.

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassInstanceMethodsEnhancePluginDefine.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassInstanceMethodsEnhancePluginDefine.java
@@ -38,9 +38,4 @@ public abstract class ClassInstanceMethodsEnhancePluginDefine extends ClassEnhan
     protected StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
         return null;
     }
-
-    @Override
-    protected boolean implementDynamicField() {
-        return true;
-    }
 }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassStaticMethodsEnhancePluginDefine.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ClassStaticMethodsEnhancePluginDefine.java
@@ -48,9 +48,4 @@ public abstract class ClassStaticMethodsEnhancePluginDefine extends ClassEnhance
     protected InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
         return null;
     }
-
-    @Override
-    protected boolean implementDynamicField() {
-        return true;
-    }
 }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ConstructorInter.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/ConstructorInter.java
@@ -64,9 +64,9 @@ public class ConstructorInter {
     public void intercept(@This Object obj,
                           @AllArguments Object[] allArguments) {
         try {
-            EnhancedInstance targetObject = (EnhancedInstance) obj;
+//            EnhancedInstance targetObject = (EnhancedInstance) obj;
 
-            interceptor.onConstruct(targetObject, allArguments);
+            interceptor.onConstruct(obj, allArguments);
         } catch (Throwable t) {
             logger.error("ConstructorInter failure.", t);
         }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInter.java
@@ -75,8 +75,8 @@ public class InstMethodsInter {
                             @SuperCall Callable<?> zuper,
                             @Origin Method method
     ) throws Throwable {
-        EnhancedInstance targetObject = (EnhancedInstance) obj;
-        IMethodInterceptContext context = new MethodInterceptContext(targetObject, clazz, method, allArguments, method.getParameterTypes());
+//        EnhancedInstance targetObject = (EnhancedInstance) obj;
+        IMethodInterceptContext context = new MethodInterceptContext(obj, clazz, method, allArguments, method.getParameterTypes());
         MethodInterceptResult result = new MethodInterceptResult();
 
         Object ret = null;

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstMethodsInterWithOverrideArgs.java
@@ -74,8 +74,8 @@ public class InstMethodsInterWithOverrideArgs {
                             @Origin Method method,
                             @Morph OverrideCallable zuper
     ) throws Throwable {
-        EnhancedInstance targetObject = (EnhancedInstance) obj;
-        IMethodInterceptContext context = new MethodInterceptContext(targetObject, clazz, method, allArguments, method.getParameterTypes());
+//        EnhancedInstance targetObject = (EnhancedInstance) obj;
+        IMethodInterceptContext context = new MethodInterceptContext(obj, clazz, method, allArguments, method.getParameterTypes());
         MethodInterceptResult result = new MethodInterceptResult();
         Object ret = null;
 

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceConstructorInterceptor.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/interceptor/enhance/InstanceConstructorInterceptor.java
@@ -30,5 +30,5 @@ public interface InstanceConstructorInterceptor {
     /**
      * Called before the origin constructor invocation.
      */
-    void onConstruct(EnhancedInstance objInst, Object[] allArguments);
+    void onConstruct(Object objInst, Object[] allArguments);
 }

--- a/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ClassMatch.java
+++ b/agent-core/src/main/java/org/apache/skywalking/apm/agent/core/plugin/match/ClassMatch.java
@@ -42,9 +42,9 @@ public interface ClassMatch {
         if (typeDescription.isInterface()) {
             return false;
         }
-        if (typeDescription.isAssignableTo(EnhancedInstance.class)) {
-            return false;
-        }
+//        if (typeDescription.isAssignableTo(EnhancedInstance.class)) {
+//            return false;
+//        }
         return true;
     }
 

--- a/agent-main/src/main/java/cloud/erda/agent/JavaAgent.java
+++ b/agent-main/src/main/java/cloud/erda/agent/JavaAgent.java
@@ -61,7 +61,7 @@ public class JavaAgent {
 
         final PluginFinder pluginFinder;
         try {
-            pluginFinder = new PluginFinder(new PluginBootstrap().loadPlugins());
+            pluginFinder = new PluginFinder(new PluginBootstrap().loadPlugins(config));
             ServiceManager.INSTANCE.boot();
         } catch (Exception e) {
             logger.error(e, "Java agent initialized failure. Shutting down.");
@@ -124,7 +124,7 @@ public class JavaAgent {
                     }
                 }
                 if (context.isEnhanced()) {
-                    logger.debug("Finish the prepare stage for {}.", typeDescription.getName());
+//                    logger.debug("Finish the prepare stage for {}.", typeDescription.getName());
                 }
 
                 return newBuilder;
@@ -145,7 +145,7 @@ public class JavaAgent {
         public void onTransformation(TypeDescription typeDescription, ClassLoader classLoader, JavaModule module,
                                      boolean loaded, DynamicType dynamicType) {
             if (logger.isDebugEnable()) {
-                logger.debug("On Transformation class {}.", typeDescription.getName());
+                logger.debug("Enhance class {} completely.", typeDescription.getName());
             }
 
             InstrumentDebuggingClass.INSTANCE.log(typeDescription, dynamicType);

--- a/agent-main/src/main/java/cloud/erda/agent/JavaAgent.java
+++ b/agent-main/src/main/java/cloud/erda/agent/JavaAgent.java
@@ -116,6 +116,7 @@ public class JavaAgent {
             if (pluginDefines.size() > 0) {
                 DynamicType.Builder<?> newBuilder = builder;
                 EnhanceContext context = new EnhanceContext();
+                context.setTypeDescription(typeDescription);
                 for (AbstractClassEnhancePluginDefine define : pluginDefines) {
                     DynamicType.Builder<?> possibleNewBuilder = define.define(typeDescription.getTypeName(), newBuilder, classLoader, context);
                     if (possibleNewBuilder != null) {

--- a/agent-plugins/agent-app-insight-common/src/main/java/cloud/erda/agent/plugin/app/insight/StopWatch.java
+++ b/agent-plugins/agent-app-insight-common/src/main/java/cloud/erda/agent/plugin/app/insight/StopWatch.java
@@ -16,8 +16,6 @@
 
 package cloud.erda.agent.plugin.app.insight;
 
-import cloud.erda.agent.core.utils.DateTime;
-
 /**
  * @author liuhaoyang
  * @since 2019-01-21 17:42

--- a/agent-plugins/agent-dubbo-2.7.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-dubbo-2.7.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-dubbo-2.7.x=cloud.erda.agent.plugin.asf.dubbo.DubboInstrumentation
+dubbo=cloud.erda.agent.plugin.asf.dubbo.DubboInstrumentation

--- a/agent-plugins/agent-feign-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-feign-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-feign-http-9.x=cloud.erda.agent.plugin.http.v9.define.DefaultHttpClientInstrumentation
+feign=cloud.erda.agent.plugin.http.v9.define.DefaultHttpClientInstrumentation

--- a/agent-plugins/agent-httpClient-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-httpClient-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-httpclient-4.x=cloud.erda.agent.plugin.httpClient.v4.define.AbstractHttpClientInstrumentation
-httpclient-4.x=cloud.erda.agent.plugin.httpClient.v4.define.InternalHttpClientInstrumentation
-httpclient-4.x=cloud.erda.agent.plugin.httpClient.v4.define.MinimalHttpClientInstrumentation
+apache_httpclient=cloud.erda.agent.plugin.httpClient.v4.define.AbstractHttpClientInstrumentation
+apache_httpclient=cloud.erda.agent.plugin.httpClient.v4.define.InternalHttpClientInstrumentation
+apache_httpclient=cloud.erda.agent.plugin.httpClient.v4.define.MinimalHttpClientInstrumentation

--- a/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/SessionRequestConstructorInterceptor.java
+++ b/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/SessionRequestConstructorInterceptor.java
@@ -28,7 +28,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
  */
 public class SessionRequestConstructorInterceptor implements InstanceConstructorInterceptor {
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(ThreadTransferInfo.LOCAL.get());
         ThreadTransferInfo.LOCAL.remove();
     }

--- a/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/define/HttpAsyncClientInstrumentation.java
+++ b/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/define/HttpAsyncClientInstrumentation.java
@@ -79,4 +79,9 @@ public class HttpAsyncClientInstrumentation extends ClassInstanceMethodsEnhanceP
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/define/HttpAsyncRequestExecutorInstrumentation.java
+++ b/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/define/HttpAsyncRequestExecutorInstrumentation.java
@@ -72,4 +72,9 @@ public class HttpAsyncRequestExecutorInstrumentation extends ClassInstanceMethod
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/define/SessionRequestInstrumentation.java
+++ b/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/java/cloud/erda/agent/plugin/httpasyncclient/v4/define/SessionRequestInstrumentation.java
@@ -111,4 +111,9 @@ public class SessionRequestInstrumentation extends ClassInstanceMethodsEnhancePl
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-httpasyncclient-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-httpasyncclient-4.x=cloud.erda.agent.plugin.httpasyncclient.v4.define.HttpAsyncClientInstrumentation
-httpasyncclient-4.x=cloud.erda.agent.plugin.httpasyncclient.v4.define.HttpAsyncRequestExecutorInstrumentation
-httpasyncclient-4.x=cloud.erda.agent.plugin.httpasyncclient.v4.define.SessionRequestInstrumentation
+apache_httpasyncclient=cloud.erda.agent.plugin.httpasyncclient.v4.define.HttpAsyncClientInstrumentation
+apache_httpasyncclient=cloud.erda.agent.plugin.httpasyncclient.v4.define.HttpAsyncRequestExecutorInstrumentation
+apache_httpasyncclient=cloud.erda.agent.plugin.httpasyncclient.v4.define.SessionRequestInstrumentation
 
 

--- a/agent-plugins/agent-jdbc-plugins/agent-jdbc-commons/src/main/java/cloud/erda/agent/plugin/jdbc/JDBCStatementInterceptor.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-jdbc-commons/src/main/java/cloud/erda/agent/plugin/jdbc/JDBCStatementInterceptor.java
@@ -45,7 +45,7 @@ public class JDBCStatementInterceptor implements InstanceMethodsAroundIntercepto
     @Override
     public Object afterMethod(IMethodInterceptContext context,
                               Object ret) throws Throwable {
-        EnhancedInstance objInst = context.getInstance();
+        Object objInst = context.getInstance();
         if (((DynamicFieldEnhancedInstance) objInst).getDynamicField() == null) {
             return ret;
         }

--- a/agent-plugins/agent-jdbc-plugins/agent-jdbc-commons/src/main/java/cloud/erda/agent/plugin/jdbc/define/AbstractDriverInstrumentation.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-jdbc-commons/src/main/java/cloud/erda/agent/plugin/jdbc/define/AbstractDriverInstrumentation.java
@@ -54,4 +54,9 @@ public abstract class AbstractDriverInstrumentation extends ClassInstanceMethods
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/CallableInstrumentation.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/CallableInstrumentation.java
@@ -74,4 +74,9 @@ public class CallableInstrumentation extends ClassInstanceMethodsEnhancePluginDe
     protected ClassMatch enhanceClass() {
         return byMultiClassMatch(ENHANCE_CLASS, "com.mysql.jdbc.cj.CallableStatement");
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/ConnectionInstrumentation.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/ConnectionInstrumentation.java
@@ -139,4 +139,9 @@ public abstract class ConnectionInstrumentation extends ClassInstanceMethodsEnha
 
     @Override
     protected abstract ClassMatch enhanceClass();
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/PreparedStatementInstrumentation.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/PreparedStatementInstrumentation.java
@@ -81,4 +81,9 @@ public class PreparedStatementInstrumentation extends ClassInstanceMethodsEnhanc
     protected ClassMatch enhanceClass() {
         return byMultiClassMatch(PREPARED_STATEMENT_CLASS_NAME, MYSQL6_PREPARED_STATEMENT_CLASS_NAME);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/StatementInstrumentation.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v5/define/StatementInstrumentation.java
@@ -104,4 +104,9 @@ public class StatementInstrumentation extends ClassInstanceMethodsEnhancePluginD
     protected ClassMatch enhanceClass() {
         return byMultiClassMatch(STATEMENT_CLASS_NAME, MYSQL6_STATEMENT_CLASS_NAME);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-5.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mysql-5.x=cloud.erda.agent.plugin.jdbc.mysql.v5.define.DriverInstrumentation
-mysql-5.x=cloud.erda.agent.plugin.jdbc.mysql.v5.define.Mysql5xConnectionInstrumentation
-mysql-5.x=cloud.erda.agent.plugin.jdbc.mysql.v5.define.Mysql50ConnectionInstrumentation
-mysql-5.x=cloud.erda.agent.plugin.jdbc.mysql.v5.define.PreparedStatementInstrumentation
-mysql-5.x=cloud.erda.agent.plugin.jdbc.mysql.v5.define.StatementInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v5.define.DriverInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v5.define.Mysql5xConnectionInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v5.define.Mysql50ConnectionInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v5.define.PreparedStatementInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v5.define.StatementInstrumentation
 #mysql-5.x=cloud.erda.agent.plugin.jdbc.mysql.v5.define.CallableInstrumentation

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-8.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v8/define/AbstractMysqlInstrumentation.java
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-8.x-plugin/src/main/java/cloud/erda/agent/plugin/jdbc/mysql/v8/define/AbstractMysqlInstrumentation.java
@@ -48,4 +48,9 @@ public abstract class AbstractMysqlInstrumentation extends ClassInstanceMethodsE
     protected String[] witnessClasses() {
         return new String[]{Constants.WITNESS_MYSQL_8X_CLASS};
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jdbc-plugins/agent-mysql-8.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-jdbc-plugins/agent-mysql-8.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mysql-8.x=cloud.erda.agent.plugin.jdbc.mysql.v8.define.ConnectionInstrumentation
-mysql-8.x=cloud.erda.agent.plugin.jdbc.mysql.v8.define.PreparedStatementInstrumentation
-mysql-8.x=cloud.erda.agent.plugin.jdbc.mysql.v8.define.StatementInstrumentation
-mysql-8.x=cloud.erda.agent.plugin.jdbc.mysql.v8.define.ConnectionImplCreateInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v8.define.ConnectionInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v8.define.PreparedStatementInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v8.define.StatementInstrumentation
+mysql=cloud.erda.agent.plugin.jdbc.mysql.v8.define.ConnectionImplCreateInstrumentation

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisClusterConstructorWithHostAndPortArgInterceptor.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisClusterConstructorWithHostAndPortArgInterceptor.java
@@ -20,14 +20,13 @@
 package cloud.erda.agent.plugin.jedis.v2;
 
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.DynamicFieldEnhancedInstance;
-import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedInstance;
 import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceConstructorInterceptor;
 import redis.clients.jedis.HostAndPort;
 
 public class JedisClusterConstructorWithHostAndPortArgInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         HostAndPort hostAndPort = (HostAndPort) allArguments[0];
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(hostAndPort.getHost() + ":" + hostAndPort.getPort());
     }

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisClusterConstructorWithListHostAndPortArgInterceptor.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisClusterConstructorWithListHostAndPortArgInterceptor.java
@@ -28,7 +28,7 @@ import java.util.Set;
 public class JedisClusterConstructorWithListHostAndPortArgInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         StringBuilder redisConnInfo = new StringBuilder();
         Set<HostAndPort> hostAndPorts = (Set<HostAndPort>) allArguments[0];
         for (HostAndPort hostAndPort : hostAndPorts) {

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisConstructorWithShardInfoArgInterceptor.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisConstructorWithShardInfoArgInterceptor.java
@@ -26,7 +26,7 @@ import redis.clients.jedis.JedisShardInfo;
 public class JedisConstructorWithShardInfoArgInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         String redisConnInfo;
         JedisShardInfo shardInfo = (JedisShardInfo) allArguments[0];
         redisConnInfo = shardInfo.getHost() + ":" + shardInfo.getPort();

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisConstructorWithStringArgInterceptor.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisConstructorWithStringArgInterceptor.java
@@ -25,7 +25,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
 public class JedisConstructorWithStringArgInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         String host = (String) allArguments[0];
         String port = "6379";
         if (allArguments.length > 1) {

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisConstructorWithUriArgInterceptor.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisConstructorWithUriArgInterceptor.java
@@ -27,7 +27,7 @@ import java.net.URI;
 public class JedisConstructorWithUriArgInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         URI uri = (URI) allArguments[0];
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(uri.getHost() + ":" + uri.getPort());
     }

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisMethodInterceptor.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/JedisMethodInterceptor.java
@@ -40,7 +40,7 @@ public class JedisMethodInterceptor implements InstanceMethodsAroundInterceptor 
 
     @Override
     public void beforeMethod(IMethodInterceptContext context, MethodInterceptResult result) throws Throwable {
-        EnhancedInstance objInst = context.getInstance();
+        Object objInst = context.getInstance();
         Method method = context.getMethod();
         Object[] allArguments = context.getArguments();
 

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/define/JedisClusterInstrumentation.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/define/JedisClusterInstrumentation.java
@@ -94,4 +94,9 @@ public class JedisClusterInstrumentation extends ClassInstanceMethodsEnhancePlug
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/define/JedisInstrumentation.java
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/java/cloud/erda/agent/plugin/jedis/v2/define/JedisInstrumentation.java
@@ -106,4 +106,9 @@ public class JedisInstrumentation extends ClassInstanceMethodsEnhancePluginDefin
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-jedis-2.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-jedis-2.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-jedis-2.x=cloud.erda.agent.plugin.jedis.v2.define.JedisClusterInstrumentation
-jedis-2.x=cloud.erda.agent.plugin.jedis.v2.define.JedisInstrumentation
+jedis=cloud.erda.agent.plugin.jedis.v2.define.JedisClusterInstrumentation
+jedis=cloud.erda.agent.plugin.jedis.v2.define.JedisInstrumentation

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/ClientOptionsConstructorInterceptor.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/ClientOptionsConstructorInterceptor.java
@@ -28,6 +28,6 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
 public class ClientOptionsConstructorInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
     }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/RedisChannelWriterInterceptor.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/RedisChannelWriterInterceptor.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 public class RedisChannelWriterInterceptor implements InstanceMethodsAroundInterceptor, InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         DynamicFieldEnhancedInstance optionsInst = (DynamicFieldEnhancedInstance) allArguments[0];
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(optionsInst.getDynamicField());
     }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/RedisClientConstructorInterceptor.java
@@ -27,7 +27,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
 public class RedisClientConstructorInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         RedisURI redisURI = (RedisURI) allArguments[1];
         RedisClient redisClient = (RedisClient) objInst;
         DynamicFieldEnhancedInstance optionsInst = (DynamicFieldEnhancedInstance) redisClient.getOptions();

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/RedisClusterClientConstructorInterceptor.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/RedisClusterClientConstructorInterceptor.java
@@ -27,7 +27,7 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
 public class RedisClusterClientConstructorInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         @SuppressWarnings("unchecked") Iterable<RedisURI> redisURIs = (Iterable<RedisURI>) allArguments[1];
         RedisClusterClient redisClusterClient = (RedisClusterClient) objInst;
         StringBuilder peer = new StringBuilder();

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/AbstractRedisClientInstrumentation.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/AbstractRedisClientInstrumentation.java
@@ -66,4 +66,9 @@ public class AbstractRedisClientInstrumentation extends ClassInstanceMethodsEnha
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/AsyncCommandInstrumentation.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/AsyncCommandInstrumentation.java
@@ -67,4 +67,9 @@ public class AsyncCommandInstrumentation extends ClassInstanceMethodsEnhancePlug
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/ClientOptionsInstrumentation.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/ClientOptionsInstrumentation.java
@@ -60,4 +60,9 @@ public class ClientOptionsInstrumentation extends ClassInstanceMethodsEnhancePlu
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/RedisChannelWriterInstrumentation.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/RedisChannelWriterInstrumentation.java
@@ -81,4 +81,9 @@ public class RedisChannelWriterInstrumentation extends ClassInstanceMethodsEnhan
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/RedisClientInstrumentation.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/RedisClientInstrumentation.java
@@ -61,4 +61,9 @@ public class RedisClientInstrumentation extends ClassInstanceMethodsEnhancePlugi
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/RedisClusterClientInstrumentation.java
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/java/cloud/erda/agent/plugin/lettuce/v5/define/RedisClusterClientInstrumentation.java
@@ -60,4 +60,9 @@ public class RedisClusterClientInstrumentation extends ClassInstanceMethodsEnhan
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-lettuce-plugins/agent-lettuce-5.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -1,6 +1,6 @@
-letture-5.x=cloud.erda.agent.plugin.lettuce.v5.define.AbstractRedisClientInstrumentation
-letture-5.x=cloud.erda.agent.plugin.lettuce.v5.define.AsyncCommandInstrumentation
-letture-5.x=cloud.erda.agent.plugin.lettuce.v5.define.RedisClientInstrumentation
-letture-5.x=cloud.erda.agent.plugin.lettuce.v5.define.RedisChannelWriterInstrumentation
-letture-5.x=cloud.erda.agent.plugin.lettuce.v5.define.ClientOptionsInstrumentation
-letture-5.x=cloud.erda.agent.plugin.lettuce.v5.define.RedisClusterClientInstrumentation
+letture=cloud.erda.agent.plugin.lettuce.v5.define.AbstractRedisClientInstrumentation
+letture=cloud.erda.agent.plugin.lettuce.v5.define.AsyncCommandInstrumentation
+letture=cloud.erda.agent.plugin.lettuce.v5.define.RedisClientInstrumentation
+letture=cloud.erda.agent.plugin.lettuce.v5.define.RedisChannelWriterInstrumentation
+letture=cloud.erda.agent.plugin.lettuce.v5.define.ClientOptionsInstrumentation
+letture=cloud.erda.agent.plugin.lettuce.v5.define.RedisClusterClientInstrumentation

--- a/agent-plugins/agent-log-plugins/agent-log4j2-plugin/src/main/java/cloud/erda/agent/plugin/log4j2/pattern/PatternLayoutInterceptor.java
+++ b/agent-plugins/agent-log-plugins/agent-log4j2-plugin/src/main/java/cloud/erda/agent/plugin/log4j2/pattern/PatternLayoutInterceptor.java
@@ -30,7 +30,7 @@ public class PatternLayoutInterceptor implements InstanceMethodsAroundIntercepto
 
     @Override
     public void beforeMethod(IMethodInterceptContext context, MethodInterceptResult result) throws Throwable {
-        EnhancedInstance instance = context.getInstance();
+        Object instance = context.getInstance();
         if (!(instance instanceof PatternLayout.Builder)) {
             return;
         }

--- a/agent-plugins/agent-log-plugins/agent-logback-plugin/src/main/java/cloud/erda/agent/plugin/logback/appender/ContextInitializerConstructorInterceptor.java
+++ b/agent-plugins/agent-log-plugins/agent-logback-plugin/src/main/java/cloud/erda/agent/plugin/logback/appender/ContextInitializerConstructorInterceptor.java
@@ -28,7 +28,7 @@ public class ContextInitializerConstructorInterceptor implements InstanceConstru
     private static final ILog log = LogManager.getLogger(ContextInitializerConstructorInterceptor.class);
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         LoggerContext lc = (LoggerContext) allArguments[0];
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(lc);
     }

--- a/agent-plugins/agent-log-plugins/agent-logback-plugin/src/main/java/cloud/erda/agent/plugin/logback/appender/ContextInitializerInstrumentation.java
+++ b/agent-plugins/agent-log-plugins/agent-logback-plugin/src/main/java/cloud/erda/agent/plugin/logback/appender/ContextInitializerInstrumentation.java
@@ -94,4 +94,9 @@ public class ContextInitializerInstrumentation extends ClassInstanceMethodsEnhan
     protected ClassMatch enhanceClass() {
         return NameMatch.byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-log-plugins/agent-logback-spring-boot-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-log-plugins/agent-logback-spring-boot-plugin/src/main/resources/erda-agent-plugin.def
@@ -1,1 +1,1 @@
-error.logback.spring.boot=cloud.erda.agent.plugin.logback.spring.boot.LogbackLoggingSystemInstrumentation
+logback=cloud.erda.agent.plugin.logback.spring.boot.LogbackLoggingSystemInstrumentation

--- a/agent-plugins/agent-microservice-plugin/src/main/resources/META-INF/services/org.apache.skywalking.apm.agent.core.boot.BootService
+++ b/agent-plugins/agent-microservice-plugin/src/main/resources/META-INF/services/org.apache.skywalking.apm.agent.core.boot.BootService
@@ -1,1 +1,1 @@
-cloud.erda.agent.plugin.microservice.MicroServiceScheduledService
+#cloud.erda.agent.plugin.microservice.MicroServiceScheduledService

--- a/agent-plugins/agent-microservice-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-microservice-plugin/src/main/resources/erda-agent-plugin.def
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-configcenter=cloud.erda.agent.plugin.microservice.define.ConfigCenterInstrumentation
-registercenter=cloud.erda.agent.plugin.microservice.define.ProviderInstrumentation
-registercenter=cloud.erda.agent.plugin.microservice.define.ConsumerInstrumentation
+#
+#microservice=cloud.erda.agent.plugin.microservice.define.ConfigCenterInstrumentation
+#microservice=cloud.erda.agent.plugin.microservice.define.ProviderInstrumentation
+#microservice=cloud.erda.agent.plugin.microservice.define.ConsumerInstrumentation

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/AbstractOkhttpInstrumentation.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/AbstractOkhttpInstrumentation.java
@@ -29,4 +29,9 @@ public abstract class AbstractOkhttpInstrumentation extends ClassInstanceMethods
     protected final String[] witnessClasses() {
         return new String[] {WITHNESS_CLASSES};
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/AsyncCallInstrumentation.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/AsyncCallInstrumentation.java
@@ -85,4 +85,9 @@ public class AsyncCallInstrumentation extends AbstractOkhttpInstrumentation {
     protected ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/CallbackInstrumentation.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/CallbackInstrumentation.java
@@ -89,4 +89,9 @@ public class CallbackInstrumentation extends AbstractOkhttpInstrumentation {
     protected ClassMatch enhanceClass() {
         return byHierarchyMatch(new String[] {ENHANCE_CLASS});
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/RealCallInstrumentation.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/java/cloud/erda/agent/plugin/okhttp/v4/define/RealCallInstrumentation.java
@@ -103,4 +103,9 @@ public class RealCallInstrumentation extends ClassInstanceMethodsEnhancePluginDe
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-okhttp-4.x=cloud.erda.agent.plugin.okhttp.v4.define.RealCallInstrumentation
-okhttp-4.x=cloud.erda.agent.plugin.okhttp.v4.define.AsyncCallInstrumentation
-okhttp-4.x=cloud.erda.agent.plugin.okhttp.v4.define.CallbackInstrumentation
+okhttp=cloud.erda.agent.plugin.okhttp.v4.define.RealCallInstrumentation
+okhttp=cloud.erda.agent.plugin.okhttp.v4.define.AsyncCallInstrumentation
+okhttp=cloud.erda.agent.plugin.okhttp.v4.define.CallbackInstrumentation

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/AsyncCallInterceptor.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/AsyncCallInterceptor.java
@@ -45,7 +45,7 @@ public class AsyncCallInterceptor implements InstanceConstructorInterceptor, Ins
     private static ILog log = LogManager.getLogger(AsyncCallInterceptor.class);
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         /*
          * The first argument of constructor is not the `real` parameter when the enhance class is an inner class. This
          * is the JDK compiler mechanism.

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/EnhanceRequiredInfo.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/EnhanceRequiredInfo.java
@@ -27,9 +27,9 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.EnhancedI
  */
 public class EnhanceRequiredInfo {
     private TracerSnapshot tracerSnapshot;
-    private EnhancedInstance realCallEnhance;
+    private Object realCallEnhance;
 
-    public EnhanceRequiredInfo(EnhancedInstance realCallEnhance, TracerSnapshot tracerSnapshot) {
+    public EnhanceRequiredInfo(Object realCallEnhance, TracerSnapshot tracerSnapshot) {
         this.tracerSnapshot = tracerSnapshot;
         this.realCallEnhance = realCallEnhance;
     }
@@ -38,7 +38,7 @@ public class EnhanceRequiredInfo {
         return tracerSnapshot;
     }
 
-    public EnhancedInstance getRealCallEnhance() {
+    public Object getRealCallEnhance() {
         return realCallEnhance;
     }
 }

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/EnqueueInterceptor.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/EnqueueInterceptor.java
@@ -76,7 +76,7 @@ public class EnqueueInterceptor implements InstanceMethodsAroundInterceptor,Inst
     }
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(allArguments[1]);
     }
 }

--- a/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/RealCallInterceptor.java
+++ b/agent-plugins/agent-okhttp-plugins/agent-okhttp-common/src/main/java/cloud/erda/agent/plugin/okhttp/common/RealCallInterceptor.java
@@ -42,7 +42,7 @@ public class RealCallInterceptor implements InstanceMethodsAroundInterceptor, In
     private static ILog log = LogManager.getLogger(RealCallInterceptor.class);
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         ((DynamicFieldEnhancedInstance)objInst).setDynamicField(allArguments[1]);
     }
 

--- a/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/RedisClientConstructorInterceptor.java
+++ b/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/RedisClientConstructorInterceptor.java
@@ -27,6 +27,6 @@ import org.apache.skywalking.apm.agent.core.plugin.interceptor.enhance.InstanceC
 public class RedisClientConstructorInterceptor implements InstanceConstructorInterceptor {
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
     }
 }

--- a/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/RedisConnectionSendInterceptor.java
+++ b/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/RedisConnectionSendInterceptor.java
@@ -53,7 +53,7 @@ public class RedisConnectionSendInterceptor implements InstanceMethodsAroundInte
     private static final ILog logger = LogManager.getLogger(RedisConnectionSendInterceptor.class);
 
     @Override
-    public void onConstruct(EnhancedInstance objInst, Object[] allArguments) {
+    public void onConstruct(Object objInst, Object[] allArguments) {
         String peer = (String) ((DynamicFieldEnhancedInstance) allArguments[0]).getDynamicField();
         if (peer == null) {
             try {

--- a/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/define/RedisClientInstrumentation.java
+++ b/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/define/RedisClientInstrumentation.java
@@ -62,4 +62,9 @@ public class RedisClientInstrumentation extends ClassInstanceMethodsEnhancePlugi
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/define/RedisConnectionInstrumentation.java
+++ b/agent-plugins/agent-redisson-3.x-plugin/src/main/java/cloud/erda/agent/plugin/redisson/v3/define/RedisConnectionInstrumentation.java
@@ -80,5 +80,10 @@ public class RedisConnectionInstrumentation extends ClassInstanceMethodsEnhanceP
     public ClassMatch enhanceClass() {
         return byName(ENHANCE_CLASS);
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }
 

--- a/agent-plugins/agent-redisson-3.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-redisson-3.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -1,4 +1,4 @@
-redisson-3.x=cloud.erda.agent.plugin.redisson.v3.define.ConnectionManagerInstrumentation
-redisson-3.x=cloud.erda.agent.plugin.redisson.v3.define.RedisConnectionInstrumentation
-redisson-3.x=cloud.erda.agent.plugin.redisson.v3.define.RedisClientInstrumentation
-redisson-3.x=cloud.erda.agent.plugin.redisson.v3.define.CommandAsyncInstrumentation
+redisson=cloud.erda.agent.plugin.redisson.v3.define.ConnectionManagerInstrumentation
+redisson=cloud.erda.agent.plugin.redisson.v3.define.RedisConnectionInstrumentation
+redisson=cloud.erda.agent.plugin.redisson.v3.define.RedisClientInstrumentation
+redisson=cloud.erda.agent.plugin.redisson.v3.define.CommandAsyncInstrumentation

--- a/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/MessageSendInterceptor.java
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/MessageSendInterceptor.java
@@ -107,7 +107,7 @@ public class MessageSendInterceptor implements InstanceMethodsAroundInterceptor 
         if (IS_SYNC.get()) {
             context.setAttachment(Constants.Keys.METRIC_BUILDER, transactionMetricBuilder);
         } else {
-            EnhancedInstance instance = (EnhancedInstance) allArguments[6];
+            Object instance = allArguments[6];
             MessageSendAsyncInfo info = new MessageSendAsyncInfo(tracer.capture(), transactionMetricBuilder);
             ((DynamicFieldEnhancedInstance)instance).setDynamicField(info);
         }

--- a/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/ConsumeMessageConcurrentlyInstrumentation.java
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/ConsumeMessageConcurrentlyInstrumentation.java
@@ -69,4 +69,9 @@ public class ConsumeMessageConcurrentlyInstrumentation extends ClassInstanceMeth
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/ConsumeMessageOrderlyInstrumentation.java
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/ConsumeMessageOrderlyInstrumentation.java
@@ -68,4 +68,9 @@ public class ConsumeMessageOrderlyInstrumentation extends ClassInstanceMethodsEn
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/MQClientAPIImplInstrumentation.java
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/MQClientAPIImplInstrumentation.java
@@ -87,4 +87,9 @@ public class MQClientAPIImplInstrumentation extends ClassInstanceMethodsEnhanceP
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/SendCallbackInstrumentation.java
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/src/main/java/cloud/erda/agent/plugin/rocketmq/v4/define/SendCallbackInstrumentation.java
@@ -90,4 +90,9 @@ public class SendCallbackInstrumentation extends ClassInstanceMethodsEnhancePlug
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-rocketmq-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-rocketmq-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-rocketMQ-4.x=cloud.erda.agent.plugin.rocketmq.v4.define.ConsumeMessageConcurrentlyInstrumentation
-rocketMQ-4.x=cloud.erda.agent.plugin.rocketmq.v4.define.ConsumeMessageOrderlyInstrumentation
-rocketMQ-4.x=cloud.erda.agent.plugin.rocketmq.v4.define.MQClientAPIImplInstrumentation
-rocketMQ-4.x=cloud.erda.agent.plugin.rocketmq.v4.define.SendCallbackInstrumentation
+rocketMQ=cloud.erda.agent.plugin.rocketmq.v4.define.ConsumeMessageConcurrentlyInstrumentation
+rocketMQ=cloud.erda.agent.plugin.rocketmq.v4.define.ConsumeMessageOrderlyInstrumentation
+rocketMQ=cloud.erda.agent.plugin.rocketmq.v4.define.MQClientAPIImplInstrumentation
+rocketMQ=cloud.erda.agent.plugin.rocketmq.v4.define.SendCallbackInstrumentation

--- a/agent-plugins/agent-sdk-plugin/src/main/java/cloud/erda/agent/plugin/sdk/defines/MethodInvokeAnnotationInstrumentation.java
+++ b/agent-plugins/agent-sdk-plugin/src/main/java/cloud/erda/agent/plugin/sdk/defines/MethodInvokeAnnotationInstrumentation.java
@@ -71,11 +71,6 @@ public class MethodInvokeAnnotationInstrumentation extends ClassEnhancePluginDef
     }
 
     @Override
-    protected boolean implementDynamicField() {
-        return false;
-    }
-
-    @Override
     protected StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
         return new StaticMethodsInterceptPoint[]{
                 new StaticMethodsInterceptPoint() {

--- a/agent-plugins/agent-sdk-plugin/src/main/java/cloud/erda/agent/plugin/sdk/defines/PackageInterceptInstrumentation.java
+++ b/agent-plugins/agent-sdk-plugin/src/main/java/cloud/erda/agent/plugin/sdk/defines/PackageInterceptInstrumentation.java
@@ -74,11 +74,6 @@ public class PackageInterceptInstrumentation extends ClassEnhancePluginDefine {
     }
 
     @Override
-    protected boolean implementDynamicField() {
-        return false;
-    }
-
-    @Override
     protected StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
         return new StaticMethodsInterceptPoint[]{
                 new StaticMethodsInterceptPoint() {

--- a/agent-plugins/agent-sdk-plugin/src/main/java/cloud/erda/agent/plugin/sdk/defines/TraceAnnotationInstrumentation.java
+++ b/agent-plugins/agent-sdk-plugin/src/main/java/cloud/erda/agent/plugin/sdk/defines/TraceAnnotationInstrumentation.java
@@ -71,11 +71,6 @@ public class TraceAnnotationInstrumentation extends ClassEnhancePluginDefine {
     }
 
     @Override
-    protected boolean implementDynamicField() {
-        return false;
-    }
-
-    @Override
     protected StaticMethodsInterceptPoint[] getStaticMethodsInterceptPoints() {
         return new StaticMethodsInterceptPoint[]{
                 new StaticMethodsInterceptPoint() {

--- a/agent-plugins/agent-sdk-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-sdk-plugin/src/main/resources/erda-agent-plugin.def
@@ -1,4 +1,4 @@
-msp-sdk=cloud.erda.agent.plugin.sdk.defines.TracerInstrumentation
-msp-sdk=cloud.erda.agent.plugin.sdk.defines.TraceAnnotationInstrumentation
-msp-sdk=cloud.erda.agent.plugin.sdk.defines.MethodInvokeAnnotationInstrumentation
-msp-sdk=cloud.erda.agent.plugin.sdk.defines.ExecutorServiceSubmitInstrumentation
+monitorsdk=cloud.erda.agent.plugin.sdk.defines.TracerInstrumentation
+monitorsdk=cloud.erda.agent.plugin.sdk.defines.TraceAnnotationInstrumentation
+monitorsdk=cloud.erda.agent.plugin.sdk.defines.MethodInvokeAnnotationInstrumentation
+monitorsdk=cloud.erda.agent.plugin.sdk.defines.ExecutorServiceSubmitInstrumentation

--- a/agent-plugins/agent-sharding-sphere-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-sharding-sphere-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-sharding-sphere-4.x=cloud.erda.agent.plugin.shardingsphere.v4.define.ProxyRootInvokeInstrumentation
-sharding-sphere-4.x=cloud.erda.agent.plugin.shardingsphere.v4.define.JDBCRootInvokeInstrumentation
-sharding-sphere-4.x=cloud.erda.agent.plugin.shardingsphere.v4.define.ParseInstrumentation
-sharding-sphere-4.x=cloud.erda.agent.plugin.shardingsphere.v4.define.ExecuteInstrumentation
+shardingSphere=cloud.erda.agent.plugin.shardingsphere.v4.define.ProxyRootInvokeInstrumentation
+shardingSphere=cloud.erda.agent.plugin.shardingsphere.v4.define.JDBCRootInvokeInstrumentation
+shardingSphere=cloud.erda.agent.plugin.shardingsphere.v4.define.ParseInstrumentation
+shardingSphere=cloud.erda.agent.plugin.shardingsphere.v4.define.ExecuteInstrumentation

--- a/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/concurrent/define/FailureCallbackInstrumentation.java
+++ b/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/concurrent/define/FailureCallbackInstrumentation.java
@@ -66,4 +66,9 @@ public class FailureCallbackInstrumentation extends ClassInstanceMethodsEnhanceP
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/concurrent/define/ListenableFutureCallbackInstrumentation.java
+++ b/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/concurrent/define/ListenableFutureCallbackInstrumentation.java
@@ -85,5 +85,10 @@ public class ListenableFutureCallbackInstrumentation extends ClassInstanceMethod
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }
 

--- a/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/concurrent/define/SuccessCallbackInstrumentation.java
+++ b/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/concurrent/define/SuccessCallbackInstrumentation.java
@@ -72,4 +72,9 @@ public class SuccessCallbackInstrumentation extends ClassInstanceMethodsEnhanceP
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-spring-plugins/agent-concurrent-util-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-spring-concurrent-util-4.x=cloud.erda.agent.plugin.spring.concurrent.define.FailureCallbackInstrumentation
-spring-concurrent-util-4.x=cloud.erda.agent.plugin.spring.concurrent.define.SuccessCallbackInstrumentation
-spring-concurrent-util-4.x=cloud.erda.agent.plugin.spring.concurrent.define.ListenableFutureCallbackInstrumentation
+spring_concurrentUtil=cloud.erda.agent.plugin.spring.concurrent.define.FailureCallbackInstrumentation
+spring_concurrentUtil=cloud.erda.agent.plugin.spring.concurrent.define.SuccessCallbackInstrumentation
+spring_concurrentUtil=cloud.erda.agent.plugin.spring.concurrent.define.ListenableFutureCallbackInstrumentation

--- a/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/async/define/ResponseExtractorFutureInstrumentation.java
+++ b/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/async/define/ResponseExtractorFutureInstrumentation.java
@@ -104,5 +104,10 @@ public class ResponseExtractorFutureInstrumentation extends ClassInstanceMethods
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }
 

--- a/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/async/define/RestTemplateInstrumentation.java
+++ b/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/async/define/RestTemplateInstrumentation.java
@@ -100,4 +100,9 @@ public class RestTemplateInstrumentation extends ClassInstanceMethodsEnhancePlug
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/sync/define/RestTemplateInstrumentation.java
+++ b/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/java/cloud/erda/agent/plugin/spring/resttemplate/sync/define/RestTemplateInstrumentation.java
@@ -119,4 +119,9 @@ public class RestTemplateInstrumentation extends ClassInstanceMethodsEnhancePlug
                 }
         };
     }
+
+    @Override
+    protected boolean implementDynamicField() {
+        return true;
+    }
 }

--- a/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/resources/erda-agent-plugin.def
+++ b/agent-plugins/agent-spring-plugins/agent-resttemplate-4.x-plugin/src/main/resources/erda-agent-plugin.def
@@ -14,6 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-spring-resttemplate-4.x=cloud.erda.agent.plugin.spring.resttemplate.sync.define.RestTemplateInstrumentation
-spring-resttemplate-4.x=cloud.erda.agent.plugin.spring.resttemplate.async.define.ResponseExtractorFutureInstrumentation
-spring-resttemplate-4.x=cloud.erda.agent.plugin.spring.resttemplate.async.define.RestTemplateInstrumentation
+resttemplate=cloud.erda.agent.plugin.spring.resttemplate.sync.define.RestTemplateInstrumentation
+resttemplate=cloud.erda.agent.plugin.spring.resttemplate.async.define.ResponseExtractorFutureInstrumentation
+resttemplate=cloud.erda.agent.plugin.spring.resttemplate.async.define.RestTemplateInstrumentation


### PR DESCRIPTION
1. refactor the implementation of enhanced classes
2. By default, dynamicField is not implemented for enhanced classes, and a way to override the implementDynamicField() method is provided in the plugin to add dynamicField to enhanced classes. eg
```
public abstract class AbstractDriverInstrumentation extends ClassInstanceMethodsEnhancePluginDefine {

    @Override
    protected final ConstructorInterceptPoint[] getConstructorsInterceptPoints() {
        return new ConstructorInterceptPoint[0];
    }

    @Override
    protected final InstanceMethodsInterceptPoint[] getInstanceMethodsInterceptPoints() {
        return new InstanceMethodsInterceptPoint[]{
                new InstanceMethodsInterceptPoint() {
                    @Override
                    public ElementMatcher<MethodDescription> getMethodsMatcher() {
                        return named("connect");
                    }

                    @Override
                    public String getMethodsInterceptor() {
                        return Constants.DRIVER_INTERCEPT_CLASS;
                    }

                    @Override
                    public boolean isOverrideArgs() {
                        return false;
                    }
                }
        };
    }

    @Override
    protected boolean implementDynamicField() {
        return true;
    }
}

```
3. Provide switches for all plugins. You can use the MSP_PLUGIN_{PLUGIN_NAME}_ENABLED environment variable to choose to enable or disable the plugin. For example, use `MSP_PLUGIN_MYSQL_ENABLED = false`, `MSP_PLUGIN_TRANTOR_ENABLED = false` disable mysql and trantor plugin. By default, all plugins are enabled.